### PR TITLE
Make script replacement atomic and document updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ This command will:
 
 > After installation, restart Termux or run `source ~/.bashrc` for the `PATH` change to take effect.
 
+## Updating
+
+To update to the latest version, run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/haiueom/termux-url-opener/main/update.sh)"
+```
+
+This command will:
+
+1. Update your package lists and upgrade installed packages.
+2. Upgrade the Python dependencies (`yt-dlp`, `spotdl`, `gallery-dl`).
+3. Download the latest `termux-url-opener` script into `~/bin`.
+4. Ensure `~/bin` is on your `PATH`.
+
+The update is safe: the new script is downloaded to a temporary file and only replaces your current one once the download succeeds. Your previous version is kept as `~/bin/termux-url-opener.bak`, so you can roll back if needed:
+
+```bash
+mv ~/bin/termux-url-opener.bak ~/bin/termux-url-opener
+```
+
 ## Usage
 Once installed, you can share an URL to Termux App or use the command line to run the script.
 

--- a/install.sh
+++ b/install.sh
@@ -42,12 +42,24 @@ log_step "Step 3: Configuring script"
 termux-setup-storage -y
 mkdir -p "$INSTALL_DIR"
 
-if curl -fLo "$INSTALL_PATH" "$SCRIPT_URL"; then
-    chmod +x "$INSTALL_PATH"
-else
-    echo -e "${RED} [!] Failed, please try again.${NC}"
+# Download to a temp file first so a failed/partial download never
+# leaves a broken script at the install path.
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+if ! curl -fLo "$TMP_FILE" "$SCRIPT_URL"; then
+    echo -e "${RED} [!] Download failed, please try again.${NC}"
     exit 1
 fi
+
+if [ ! -s "$TMP_FILE" ]; then
+    echo -e "${RED} [!] Downloaded file is empty. Aborting.${NC}"
+    exit 1
+fi
+
+chmod +x "$TMP_FILE"
+mv -f "$TMP_FILE" "$INSTALL_PATH"
+trap - EXIT
 
 log_step "Step 4: Adding $INSTALL_DIR to PATH"
 PATH_LINE='export PATH="$HOME/bin:$PATH"'

--- a/update.sh
+++ b/update.sh
@@ -31,27 +31,40 @@ log_step() {
 
 print_header
 
-log_step "Step 1: Updating dependencies"
+log_step "Step 1: Updating packages"
 pkg up -y
 
 log_step "Step 2: Updating dependencies"
 pkg install python ffmpeg curl wget deno -y
 pip install -U --no-deps yt-dlp[default] spotdl gallery-dl
 
-log_step "Step 3: Configuring script"
+log_step "Step 3: Updating script"
 termux-setup-storage -y
 mkdir -p "$INSTALL_DIR"
 
-if [ -f "$INSTALL_PATH" ]; then
-    rm -f "$INSTALL_PATH"
-fi
+# Download to a temp file first, so a failed download never
+# leaves the user without a working script.
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
 
-if curl -fLo "$INSTALL_PATH" "$SCRIPT_URL"; then
-    chmod +x "$INSTALL_PATH"
-else
-    echo -e "${RED} [!] Failed, please try again.${NC}"
+if ! curl -fLo "$TMP_FILE" "$SCRIPT_URL"; then
+    echo -e "${RED} [!] Download failed. Existing script left untouched.${NC}"
     exit 1
 fi
+
+if [ ! -s "$TMP_FILE" ]; then
+    echo -e "${RED} [!] Downloaded file is empty. Aborting.${NC}"
+    exit 1
+fi
+
+# Back up the current version before replacing it.
+if [ -f "$INSTALL_PATH" ]; then
+    cp -f "$INSTALL_PATH" "$INSTALL_PATH.bak"
+fi
+
+chmod +x "$TMP_FILE"
+mv -f "$TMP_FILE" "$INSTALL_PATH"
+trap - EXIT
 
 log_step "Step 4: Ensuring $INSTALL_DIR is on PATH"
 PATH_LINE='export PATH="$HOME/bin:$PATH"'


### PR DESCRIPTION
- Download to a temp file and mv into place only on success, so a failed or partial download never leaves a broken/missing script
- update.sh backs up the current version to .bak before replacing
- Validate the download is non-empty; clean up temp file via trap
- Fix duplicate "Updating dependencies" step label in update.sh
- Add an "Updating" section to the README with rollback instructions